### PR TITLE
Update code to work with Python3 :ambulance:

### DIFF
--- a/art.py
+++ b/art.py
@@ -24,7 +24,7 @@ def __main__():
     stippled_image.show()
     stippled_image.save("output/s-" + showtime + ".png", "PNG")
     #
-    print "Connecting image dots..."
+    print("Connecting image dots...")
     tsp_image = tsp.connect_the_dots(dotted_image)
     tsp_image.show()
     # export

--- a/dot_stippler.py
+++ b/dot_stippler.py
@@ -19,7 +19,7 @@ CIRCLE_RADIUS = 6
 def draw_dots_on(image, stretched=True):
     #
     nodes = read_in_nodes(image)
-    print "Read in",len(nodes),"nodes."
+    # print "Read in",len(nodes),"nodes."
     #
     if not stretched:
         image = magnify_image(image.size, nodes, CIRCLE_RADIUS)
@@ -73,8 +73,8 @@ def draw_dots(nodes, image):
     # clear image
     imgx, imgy = image.size
     pixels = image.load()
-    for y in xrange(imgy):
-        for x in xrange(imgx):
+    for y in range(imgy):
+        for x in range(imgx):
             pixels[x,y] = NEG_COLOR
     #
     #
@@ -108,8 +108,8 @@ def read_in_nodes(image):
     NEG_COLOR = pixels[0,0]
     print "Neg_color:", NEG_COLOR
     #
-    for i in xrange(width):
-        for j in xrange(height):
+    for i in range(width):
+        for j in range(height):
             #
             if pixels[i,j] != NEG_COLOR:
                 #

--- a/greedy_tsp.py
+++ b/greedy_tsp.py
@@ -26,10 +26,10 @@ LINE_WIDTH = 2
 def connect_the_dots(image):
     #
     nodes = read_in_nodes(image)
-    print "Read in",len(nodes),"nodes."
+    #print "Read in",len(nodes),"nodes."
     #
     lines = connect_dots_with_lines(read_in_nodes(image))
-    print "Calculated nearest neighbors."
+    print("Calculated nearest neighbors.")
     #
     return draw_lines_on_image(lines, image)
     #
@@ -104,10 +104,10 @@ def read_in_nodes(image):
     pixels = image.load()
     nodes = []
     NEG_COLOR = pixels[0,0]
-    print "Neg_color:", NEG_COLOR
+    # print "Neg_color:", NEG_COLOR
     #
-    for i in xrange(width):
-        for j in xrange(height):
+    for i in range(width):
+        for j in range(height):
             #
             if pixels[i,j] != NEG_COLOR:
                 #

--- a/magnify-art.py
+++ b/magnify-art.py
@@ -19,7 +19,7 @@ def __main__():
     stippled_image.show()
     stippled_image.save("output/s-" + image_filename + image_extension, "PNG")
     #
-    # print "Connecting image dots..."
+    # print ("Connecting image dots...")
     # tsp_image = tsp.connect_the_dots(dotted_image)
     # tsp_image.show()
     # export

--- a/vstipple.py
+++ b/vstipple.py
@@ -35,11 +35,11 @@ def voronoi_stipple(image):
   showtime = strftime("%Y%m%d%H%M%S", gmtime())
   showtime += "-" + str( num_cells )
   #
-  print "(+) Creating", num_cells,"stipples with convergence point", str(CONVERGENCE_LIMIT)+"."
+  # print "(+) Creating", num_cells,"stipples with convergence point", str(CONVERGENCE_LIMIT)+"."
   #
   centroids = [
-    [random.randrange(imgx) for x in xrange(num_cells)],
-    [random.randrange(imgy) for x in xrange(num_cells)]
+    [random.randrange(imgx) for x in range(num_cells)],
+    [random.randrange(imgy) for x in range(num_cells)]
   ]
   # 
   #
@@ -88,14 +88,14 @@ def voronoi_stipple(image):
     # If no pixels shifted, we have to increase resolution.
     if centroidal_delta == 0.0:
       resolution *= 2
-      print "(+) Increasing resolution to " + str(resolution) + "x."
+      # print "(+) Increasing resolution to " + str(resolution) + "x."
     # Break if difference below convergence point.
     elif centroidal_delta < CONVERGENCE_LIMIT * resolution:
       break
     # Increase iteration count.
     iteration += 1
   # Final print statement.
-  print "(+) Magnifying image and drawing final centroids."
+  # print "(+) Magnifying image and drawing final centroids."
   return magnify_and_draw_points(zip_points(centroids), image.size)
   #
 
@@ -104,7 +104,7 @@ def voronoi_stipple(image):
 #
 def compute_centroids(centroids, new_centroid_sums, image_size):
   centroidal_delta = 0
-  for i in xrange(len(centroids[0])):
+  for i in range(len(centroids[0])):
     if not new_centroid_sums[2][i]:
       # all pixels in region have rho = 0
         # send centroid somewhere else
@@ -133,7 +133,7 @@ def sum_regions(centroids, new_centroid_sums, rho, res_step, size):
   y_range = np.arange(res_step/2.0, imgy, res_step)
   point_matrix = list(itertools.product(x_range, y_range))
   nearest_nbr_indices = tree.query(point_matrix)[1]
-  for i in xrange(len(point_matrix)):
+  for i in range(len(point_matrix)):
     point = point_matrix[i]
     x = point[0]
     y = point[1]
@@ -176,7 +176,7 @@ def zero_lists(the_lists):
 # set every element in a list to zero
 #
 def zero_list(the_list):
-  for x in xrange( len(the_list) ):
+  for x in range( len(the_list) ):
     the_list[x] = 0
 
 #


### PR DESCRIPTION
This PR addresses #1 to update scripts to work with Python3.7 

In Python3, `zip()` returns an iterator object rather than a list of tuples so I changed to `list(zip())`

In Python3 there is no `xrange()`, but `range()` function behaves like `xrange()`. If you want code that will run on both Python2 and Python3, you can use `range()`

Some print statements were wrapped in `()`, or commented-out, because they caused errors when running with {reticulate} with `py_run_file("art.py")`